### PR TITLE
Обновление примеров

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -50,6 +50,20 @@ autopost = (
 )
 ```
 
+Also, JSON's keys for bot stats must be changed:
+
+### Was:
+```py
+async def get_stats():
+    return {"servers": len(bot.guilds), "shards": 0, "users": len(bot.users)}
+```
+
+### Became:
+```py
+async def get_stats():
+    return {"guilds": len(bot.guilds), "shards": 0, "members": len(bot.users)}
+```
+
 ## Webhook or websocket... that is the question
 
 Webhooks are no longer supported in boticordpy. You can find guide how to use boticord websocket [here](https://github.com/boticord/boticordpy/blob/master/examples/websocket.py).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,5 @@
 
-# Migration Guilde
+# Migration Guide
 
 You can use this guide to make it easier to switch to new version (3x) of boticordpy.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bot = commands.Bot(command_prefix="!")
 
 # Function that will return the current bot's stats.
 async def get_stats():
-    return {"servers": len(bot.guilds), "shards": 0, "users": len(bot.users)}
+    return {"guilds": len(bot.guilds), "shards": 0, "members": len(bot.users)}
 
 
 # Function that will be called if stats are posted successfully.

--- a/boticordpy/client.py
+++ b/boticordpy/client.py
@@ -77,7 +77,7 @@ class BoticordClient:
         _logger.info("Posting bot stats")
 
         response = await self.http.post_bot_stats(
-            bot_id, {"servers": servers, "shards": shards, "users": users}
+            bot_id, {"guilds": servers, "shards": shards, "members": users}
         )
         return boticord_types.ResourceBot.from_dict(response)
 

--- a/examples/autopost.py
+++ b/examples/autopost.py
@@ -10,7 +10,7 @@ bot = commands.Bot(command_prefix="!")
 
 # Function that will return the current bot's stats.
 async def get_stats():
-    return {"servers": len(bot.guilds), "shards": 0, "users": len(bot.users)}
+    return {"guilds": len(bot.guilds), "shards": 0, "members": len(bot.users)}
 
 
 # Function that will be called if stats are posted successfully.


### PR DESCRIPTION
Примеры были устаревшие, так как, согласно документации Boticord API v3, названия ключей в JSON были изменены. Это было исправлено.