### PR TITLE
1 second cooldown for reconnecting

### DIFF
--- a/boticordpy/websocket.py
+++ b/boticordpy/websocket.py
@@ -139,7 +139,7 @@ class BotiCordWebsocket:
         await self.connect()
 
     async def _send_ping(self) -> None:
-        if not self.ws.closed:
+        if self.not_closed:
             await asyncio.sleep(45)
             await self.ws.send_json({"event": "ping"})
 

--- a/boticordpy/websocket.py
+++ b/boticordpy/websocket.py
@@ -140,7 +140,7 @@ class BotiCordWebsocket:
         await self.connect()
 
     async def _send_ping(self) -> None:
-        if self.not_closed:
+        if not self.ws.closed:
             await asyncio.sleep(45)
             await self.ws.send_json({"event": "ping"})
 

--- a/boticordpy/websocket.py
+++ b/boticordpy/websocket.py
@@ -134,7 +134,8 @@ class BotiCordWebsocket:
             _logger.error("Token is invalid.")
             return
 
-        _logger.info("Disconnected from BotiCord. Reconnecting...")
+        _logger.info("Disconnected from BotiCord. Reconnecting in 1 second...")
+        await asyncio.sleep(1)
 
         await self.connect()
 


### PR DESCRIPTION
Посвящается сегодняшнему приколу со 100 запросами в секунду для переподключения. Добавление задержку в 1 секунду для переподключения к вебсокету.